### PR TITLE
fix: valid rut when field is undefined

### DIFF
--- a/projects/ng9-rut/src/lib/rut.validator.spec.ts
+++ b/projects/ng9-rut/src/lib/rut.validator.spec.ts
@@ -33,6 +33,12 @@ describe('RutValidator: ReactiveForms', () => {
     rutControl.setValue('7618285K');
     expect(rutValidator.validate(rutControl)).toBeNull();
   });
+
+  it('should parse undefined RUTs as valid', () => {
+    let rutControl: FormControl = new FormControl();
+    rutControl.setValue(undefined);
+    expect(rutValidator.validate(rutControl)).toBeNull();
+  });
 });
 
 @Component({
@@ -79,6 +85,13 @@ describe('RutValidator: TemplateForm', () => {
 
   it('should parse valid RUTs without formatting as valid', () => {
     nativeInput.value = '7618285K';
+    nativeInput.dispatchEvent(newEvent('input'));
+    fixture.detectChanges();
+    expect(ngModel.valid).toBe(true);
+  });
+
+  it('should parse undefined RUTs as valid', () => {
+    nativeInput.value = '';
     nativeInput.dispatchEvent(newEvent('input'));
     fixture.detectChanges();
     expect(ngModel.valid).toBe(true);

--- a/projects/ng9-rut/src/lib/rut.validator.ts
+++ b/projects/ng9-rut/src/lib/rut.validator.ts
@@ -3,7 +3,10 @@ import { NG_VALIDATORS, FormControl } from '@angular/forms';
 import { rutValidate } from 'rut-helpers';
 
 export function validateRutFactory(rutValidate: Function) {
-  return (c: FormControl) => {
+  return (c: FormControl) => {    
+    if (!c.value) {
+      return null;
+    }
     return rutValidate(c.value) ? null : { invalidRut: true };
   };
 }
@@ -16,11 +19,11 @@ export function validateRutFactory(rutValidate: Function) {
 })
 export class RutValidator {
   private validator: Function;
-
+  
   constructor() {
     this.validator = validateRutFactory(rutValidate);
   }
-
+  
   public validate(c: FormControl) {
     return this.validator(c);
   }


### PR DESCRIPTION
Se corrige bug, que obliga que el campo tenga algún valor para ser valido.